### PR TITLE
Continuous tensor I/O and recurrent execution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ next_state = runner(state=state_values, update=update_values)["state"]
 The bundle records every named value's residual columns and stores the complete
 compiler-generated initial residual, including literals. Calls may be unbatched
 or batched, and `runner.run_until(...)` supports fresh-invocation recurrent
-state transitions. See [continuous Hugging Face bundles](docs/continuous_hf.md)
-for the interface format, raw-residual path, validation rules, and recurrence
-API.
+state transitions. Both ReLU and SwiGLU graphs are supported; the compiler
+infers the machine, and SwiGLU supplies the range-free gated product needed by
+multiplication-heavy numerical graphs. See [continuous Hugging Face
+bundles](docs/continuous_hf.md) for the interface format, raw-residual path,
+validation rules, and recurrence API.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,42 @@ The compiler schedules this graph into a 16-layer decoder at hidden size 512 (th
 `d=D_MODEL` argument). Every weight is computed from the source graph. Nothing
 was trained. Compiling this example takes under ten seconds on a laptop CPU.
 
+## Continuous tensor execution
+
+Graphs can also expose named tensor inputs and outputs without token IDs,
+embedding lookup, logits, or autoregressive generation:
+
+```python
+from torchwright import ContinuousRunner, compile_continuous_hf_bundle
+from torchwright.graph import Add, InputNode
+
+state = InputNode("state", 4, value_range=(-100.0, 100.0))
+update = InputNode("update", 4, value_range=(-10.0, 10.0))
+compile_continuous_hf_bundle(
+    {"state": Add(state, update)},
+    "transition_bundle",
+    n_positions=16,
+    d=256,
+    d_head=16,
+)
+
+runner = ContinuousRunner.from_pretrained("transition_bundle")
+next_state = runner(state=state_values, update=update_values)["state"]
+```
+
+The bundle records every named value's residual columns and stores the complete
+compiler-generated initial residual, including literals. Calls may be unbatched
+or batched, and `runner.run_until(...)` supports fresh-invocation recurrent
+state transitions. See [continuous Hugging Face bundles](docs/continuous_hf.md)
+for the interface format, raw-residual path, validation rules, and recurrence
+API.
+
 ## How it works
 
 A torchwright program is a computation graph: ordinary Python wiring op calls into
-a DAG of nodes, with token embeddings at the leaves and one output node at the
-root. 
+a DAG of nodes. Token graphs have an embedding at the leaves and one token
+output at the root; continuous graphs have named `InputNode` leaves and one or
+more named tensor outputs.
 
 Ops come in three groups: linear ops (`add`, `subtract`, `concat`, etc), attention
 ops (latch a value at a marker position, read a fixed offset back,
@@ -163,7 +194,8 @@ Examples that define `create_network_parts()` compile to a bundle with
   of 1024 up to 16384, or any power of two; other widths raise. See
   `docs/rms_norm_dmodel.md`.
 - The KV cache is static: sequence length is fixed at export (`max_seq_len`,
-  default 512), and overrunning it raises.
+  default 512), and overrunning it raises. Continuous calls deliberately start
+  without KV-cache history and use their bundle's fixed `n_positions`.
 
 ## Further reading
 - [Introducing torchwright](https://ood.dev/posts/torchwright-intro/) -- the story and the constructions, from ReLU
@@ -175,6 +207,8 @@ Examples that define `create_network_parts()` compile to a bundle with
 - `docs/affine_bounds.md` -- how value bounds propagate through the graph.
 - `docs/numerical_noise.md` -- measured per-op approximation error (generated
   from `docs/op_noise_data.json`).
+- `docs/continuous_hf.md` -- compiling and recurrently running named continuous
+  tensor interfaces.
 
 ## Development
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,9 +9,13 @@
 - `ContinuousRunner.from_pretrained` validates names and shapes, supports
   unbatched and batched fp32 execution, returns named outputs from the raw final
   compiled residual, and provides a generic fresh-invocation `run_until` loop.
+- Continuous compilation supports both ReLU and SwiGLU graphs, inferred from the
+  graph or pinned with `machine=`. The SwiGLU path preserves the range-free
+  complementary-gate product for continuous numerical algorithms.
 - The custom Hugging Face model now supports standard `inputs_embeds` calls and
   exposes `forward_residual()` before final token normalization and language
-  modeling. Existing token APIs and generation remain unchanged.
+  modeling. Its checkpoint format supports biased ReLU and biased SwiGLU MLP
+  layers. Existing token APIs and generation remain unchanged.
 
 # 0.2.0 — 2026-08-08
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Unreleased
 
+## Continuous Hugging Face execution
+
+- `compile_continuous_hf_bundle` compiles named `InputNode` inputs and named
+  tensor outputs without requiring a token embedding. Bundles persist a
+  versioned residual-coordinate interface and the compiler-generated base
+  residual containing literals and pinned normalization constants.
+- `ContinuousRunner.from_pretrained` validates names and shapes, supports
+  unbatched and batched fp32 execution, returns named outputs from the raw final
+  compiled residual, and provides a generic fresh-invocation `run_until` loop.
+- The custom Hugging Face model now supports standard `inputs_embeds` calls and
+  exposes `forward_residual()` before final token normalization and language
+  modeling. Existing token APIs and generation remain unchanged.
+
 # 0.2.0 — 2026-08-08
 
 ## Schematics are readable through a typed API

--- a/docs/continuous_hf.md
+++ b/docs/continuous_hf.md
@@ -44,14 +44,27 @@ runtime input has shape `(n_positions, InputNode.d_output)`. A batched call adds
 one leading batch dimension. All inputs in a call must either be unbatched or
 have the same batch size.
 
-The source graph must use the ReLU operation library because continuous bundles
-currently target Torchwright's custom biased-ReLU decoder. It must contain at
-least one named `InputNode`, and it cannot contain a token `Embedding`. Output
-names must be non-empty; input names must also be non-empty and unique.
+Continuous bundles support both Torchwright operation libraries. The compiler
+infers a biased-ReLU or biased-SwiGLU decoder from the graph's FFN nodes. A
+mixed-machine graph is rejected, as it is by the other compiler targets. A graph
+with no FFN nodes falls back to ReLU. Pass `machine="relu"` or
+`machine="swish"` to pin the physical machine and reject a graph built from the
+other library.
+
+Use `torchwright.ops.swiglu` for continuous algorithms that multiply two live
+values. Its `multiply(a, b)` uses the complementary gated pair
+`Swish(a)·b + Swish(-a)·(-b) = a·b`: it has no product grid or declared range
+limit. The identity is exact in real arithmetic; execution still has ordinary
+fp32 rounding. ReLU's `multiply_2d` is instead a range-bounded piecewise-linear
+approximation.
+
+The graph must contain at least one named `InputNode`, and it cannot contain a
+token `Embedding`. Output names must be non-empty; input names must also be
+non-empty and unique.
 
 The other compiler controls have their usual meanings: `max_layers`,
 `optimize`, `d_hidden`, `trim_heads`, and `n_heads`. `rms_norm=False` is the
-default for continuous bundles. Enabling it preserves the compiler's pinned
+default for both machines. Enabling it preserves the compiler's pinned
 normalization constants and uses the same supported-width rules as other
 RMSNorm compilation.
 

--- a/docs/continuous_hf.md
+++ b/docs/continuous_hf.md
@@ -1,0 +1,163 @@
+# Continuous Hugging Face bundles
+
+Torchwright can compile a graph with named tensor inputs and outputs into a
+Hugging Face-style checkpoint. This is a parallel path to token compilation:
+token bundles still use an `Embedding`, tokenizer, language-model head, and
+`generate()`, while continuous bundles call the compiled transformer as a
+numerical function.
+
+For a state transition, one invocation represents
+
+\[
+S_{k+1} = T_\theta(S_k, u_k).
+\]
+
+Values stay in the transformer's residual stream throughout. They are never
+converted to token IDs or logits.
+
+## Compile a bundle
+
+Build a graph from named `InputNode` objects and pass a mapping of public output
+names to graph nodes:
+
+```python
+from torchwright import compile_continuous_hf_bundle
+from torchwright.graph import Add, InputNode, LiteralValue
+import torch
+
+state = InputNode("state", 2, value_range=(-100.0, 100.0))
+update = InputNode("update", 2, value_range=(-10.0, 10.0))
+offset = LiteralValue(torch.tensor([1.0, -2.0]))
+next_state = Add(Add(state, update), offset)
+
+compile_continuous_hf_bundle(
+    outputs={"state": next_state},
+    output_dir="state_transition",
+    n_positions=8,
+    d=256,
+    d_head=16,
+)
+```
+
+`n_positions` fixes the sequence dimension of the interface. Each unbatched
+runtime input has shape `(n_positions, InputNode.d_output)`. A batched call adds
+one leading batch dimension. All inputs in a call must either be unbatched or
+have the same batch size.
+
+The source graph must use the ReLU operation library because continuous bundles
+currently target Torchwright's custom biased-ReLU decoder. It must contain at
+least one named `InputNode`, and it cannot contain a token `Embedding`. Output
+names must be non-empty; input names must also be non-empty and unique.
+
+The other compiler controls have their usual meanings: `max_layers`,
+`optimize`, `d_hidden`, `trim_heads`, and `n_heads`. `rms_norm=False` is the
+default for continuous bundles. Enabling it preserves the compiler's pinned
+normalization constants and uses the same supported-width rules as other
+RMSNorm compilation.
+
+Compilation returns `ContinuousHFBundleReport`, containing the published path,
+layer count, fixed position count, and selected-schedule provenance.
+
+## Run named inputs and outputs
+
+`ContinuousRunner` hides the residual coordinates:
+
+```python
+from torchwright import ContinuousRunner
+import torch
+
+runner = ContinuousRunner.from_pretrained("state_transition")
+
+result = runner(
+    state=torch.zeros(8, 2),
+    update=torch.ones(8, 2),
+)
+next_state = result["state"]
+```
+
+Inputs are converted to fp32 on the model's device. Outputs are fp32 tensors
+with the same unbatched or batched convention as the inputs. Missing names,
+unexpected names, inconsistent batching, and incorrect sequence or value widths
+raise before model execution.
+
+Pass `device="cuda"` or another PyTorch device to
+`ContinuousRunner.from_pretrained` to move both the model and stored initial
+residual. A local directory and a Hugging Face Hub repository ID are accepted.
+
+## What the bundle stores
+
+A continuous bundle contains normal `config.json` and sharded model
+safetensors, plus:
+
+- `continuous_io.json`: the versioned named interface;
+- `continuous_io.safetensors`: the compiler-generated initial residual stream;
+- Torchwright's custom configuration and modeling Python files, so the model is
+  a loadable Hugging Face artifact.
+
+The JSON format starts with
+`"format": "torchwright_continuous_io_v1"`. It records the fixed number of
+positions, residual width, fp32 dtype, each input and output width and shape, and
+the exact residual columns assigned to every named value. `config.json` carries
+a `torchwright_continuous_io` pointer to both sidecars.
+
+The stored base residual has shape `(n_positions, d_model)`. It is created by
+`HeadlessTransformer.get_input_res_stream()` with zero runtime inputs, so it
+contains the same compiler-created literals and pinned RMSNorm values as
+headless execution. At runtime the runner expands and clones this tensor, then
+overwrites only the recorded input columns. There is no separately maintained
+implementation of residual initialization.
+
+The checkpoint has no tokenizer. Its one-row embedding parameter is structural
+storage required by the shared Hugging Face causal-model class; neither the
+source graph nor `ContinuousRunner` performs an embedding lookup or uses the
+language-model head.
+
+## Raw residual execution
+
+The shipped custom Hugging Face model accepts the standard `inputs_embeds`
+argument. `forward_residual()` returns the decoder output after all compiled
+layers but before the final token-oriented RMSNorm and language-model head:
+
+```python
+raw_residual = runner.model.forward_residual(
+    inputs_embeds=complete_initial_residual,
+    use_cache=False,
+)
+```
+
+Output columns in `continuous_io.json` refer to this raw tensor. Do not extract
+continuous outputs from `last_hidden_state`: when final RMSNorm is enabled,
+`last_hidden_state` is in a different numerical representation. Constructing
+`complete_initial_residual` manually is also unnecessary for normal use; call
+the runner instead.
+
+Existing token models can use `inputs_embeds` too, and their ordinary
+`input_ids`, logits, tied language-model head, and `generate()` behavior remain
+unchanged.
+
+## Recurrent execution
+
+`run_until` repeatedly feeds one named output into one named input. Each step is
+a fresh transformer invocation with `use_cache=False`; no autoregressive token
+serialization or key/value-cache history is involved.
+
+```python
+result = runner.run_until(
+    initial_state,
+    state_input="state",
+    state_output="state",
+    stop_output="converged",
+    max_steps=50,
+    update=static_update,
+)
+```
+
+The graph computes `converged`. The Python loop only decides whether another
+invocation is needed. By default it stops when every element of the named stop
+output is greater than zero, which matches Torchwright's positive/negative
+boolean convention. Supply `stop_when=lambda value: ...` to choose a different
+generic reduction. The returned mapping is the final invocation's complete
+named output.
+
+`state_input`, `state_output`, and `stop_output` are configurable; the helper
+contains no application-specific update, convergence, matrix, or SCF logic.

--- a/tests/hf/test_continuous_bundle.py
+++ b/tests/hf/test_continuous_bundle.py
@@ -5,6 +5,7 @@ import json
 import pytest
 import torch
 
+import torchwright
 from torchwright.compiler.hf import (
     CONTINUOUS_BASE_FILENAME,
     CONTINUOUS_IO_FILENAME,
@@ -17,6 +18,11 @@ from torchwright.graph import Add, InputNode, LiteralValue
 _D = 64
 _D_HEAD = 8
 _N_POSITIONS = 3
+
+
+def test_continuous_api_is_available_from_top_level() -> None:
+    assert torchwright.ContinuousRunner is ContinuousRunner
+    assert torchwright.compile_continuous_hf_bundle is compile_continuous_hf_bundle
 
 
 def _transition_graph():

--- a/tests/hf/test_continuous_bundle.py
+++ b/tests/hf/test_continuous_bundle.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 import torch
+from safetensors.torch import load_file
 
 import torchwright
 from torchwright.compiler.hf import (
@@ -14,6 +15,7 @@ from torchwright.compiler.hf import (
     compile_continuous_hf_bundle,
 )
 from torchwright.graph import Add, InputNode, LiteralValue
+from torchwright.ops.swiglu import multiply
 
 _D = 64
 _D_HEAD = 8
@@ -44,6 +46,7 @@ def continuous_bundle(tmp_path_factory):
         n_positions=_N_POSITIONS,
         d=_D,
         d_head=_D_HEAD,
+        rms_norm=True,
         verbose=False,
     )
     return path, report
@@ -64,6 +67,9 @@ def test_bundle_persists_named_layout_and_static_residual(continuous_bundle) -> 
     assert spec["inputs"]["state"]["dtype"] == "float32"
     assert len(spec["inputs"]["state"]["residual_columns"]) == 2
     assert (path / CONTINUOUS_BASE_FILENAME).is_file()
+    base = load_file(path / CONTINUOUS_BASE_FILENAME)["base_residual"]
+    assert base.abs().max() > 1e10
+    torch.testing.assert_close(base[0], base[-1])
     assert not list(path.glob(".tensor_*.npy"))
 
 
@@ -117,4 +123,30 @@ def test_run_until_feeds_state_output_into_fresh_invocation(continuous_bundle) -
 
     torch.testing.assert_close(
         result["state"], state + update + torch.tensor([1.0, -2.0])
+    )
+
+
+def test_swiglu_bundle_executes_continuous_product(tmp_path) -> None:
+    """SwiGLU continuous export preserves the range-free gated product."""
+    left = InputNode("left", 1, value_range=(-1000.0, 1000.0))
+    right = InputNode("right", 1, value_range=(-1000.0, 1000.0))
+    path = tmp_path / "swiglu"
+    compile_continuous_hf_bundle(
+        {"product": multiply(left, right)},
+        path,
+        n_positions=_N_POSITIONS,
+        d=_D,
+        d_head=_D_HEAD,
+        verbose=False,
+    )
+    config = json.loads((path / "config.json").read_text())
+    assert config["activation"] == "swish"
+    runner = ContinuousRunner.from_pretrained(path)
+    left_values = torch.tensor([[3.5], [-8.25], [999.0]])
+    right_values = torch.tensor([[-2.0], [0.125], [-777.0]])
+
+    result = runner(left=left_values, right=right_values)
+
+    torch.testing.assert_close(
+        result["product"], left_values * right_values, rtol=3e-7, atol=1e-4
     )

--- a/tests/hf/test_continuous_bundle.py
+++ b/tests/hf/test_continuous_bundle.py
@@ -1,0 +1,114 @@
+"""End-to-end continuous HF bundle and recurrent runtime tests."""
+
+import json
+
+import pytest
+import torch
+
+from torchwright.compiler.hf import (
+    CONTINUOUS_BASE_FILENAME,
+    CONTINUOUS_IO_FILENAME,
+    CONTINUOUS_IO_FORMAT,
+    ContinuousRunner,
+    compile_continuous_hf_bundle,
+)
+from torchwright.graph import Add, InputNode, LiteralValue
+
+_D = 64
+_D_HEAD = 8
+_N_POSITIONS = 3
+
+
+def _transition_graph():
+    state = InputNode("state", 2, value_range=(-10.0, 10.0))
+    update = InputNode("update", 2, value_range=(-10.0, 10.0))
+    offset = LiteralValue(torch.tensor([1.0, -2.0]))
+    next_state = Add(Add(state, update), offset)
+    converged = LiteralValue(torch.tensor([1.0]))
+    return state, update, next_state, converged
+
+
+@pytest.fixture(scope="module")
+def continuous_bundle(tmp_path_factory):
+    _state, _update, next_state, converged = _transition_graph()
+    path = tmp_path_factory.mktemp("continuous") / "bundle"
+    report = compile_continuous_hf_bundle(
+        {"state": next_state, "converged": converged},
+        path,
+        n_positions=_N_POSITIONS,
+        d=_D,
+        d_head=_D_HEAD,
+        verbose=False,
+    )
+    return path, report
+
+
+def test_bundle_persists_named_layout_and_static_residual(continuous_bundle) -> None:
+    path, report = continuous_bundle
+    spec = json.loads((path / CONTINUOUS_IO_FILENAME).read_text())
+
+    assert report.n_positions == _N_POSITIONS
+    assert report.n_layers > 0
+    assert spec["format"] == CONTINUOUS_IO_FORMAT
+    assert spec["n_positions"] == _N_POSITIONS
+    assert spec["d_model"] == _D
+    assert set(spec["inputs"]) == {"state", "update"}
+    assert set(spec["outputs"]) == {"state", "converged"}
+    assert spec["inputs"]["state"]["shape"] == [_N_POSITIONS, 2]
+    assert spec["inputs"]["state"]["dtype"] == "float32"
+    assert len(spec["inputs"]["state"]["residual_columns"]) == 2
+    assert (path / CONTINUOUS_BASE_FILENAME).is_file()
+    assert not list(path.glob(".tensor_*.npy"))
+
+
+def test_runner_matches_graph_values_and_supports_batching(continuous_bundle) -> None:
+    path, _report = continuous_bundle
+    runner = ContinuousRunner.from_pretrained(path)
+    state = torch.tensor([[1.0, 2.0], [3.0, 4.0], [-2.0, 8.0]])
+    update = torch.tensor([[0.5, -1.0], [2.0, 3.0], [1.0, -4.0]])
+
+    result = runner(state=state, update=update)
+    expected = state + update + torch.tensor([1.0, -2.0])
+    torch.testing.assert_close(result["state"], expected)
+    torch.testing.assert_close(result["converged"], torch.ones(_N_POSITIONS, 1))
+
+    batched = runner(
+        state=torch.stack([state, state * 2]),
+        update=torch.stack([update, update * 3]),
+    )
+    expected_batch = torch.stack(
+        [
+            expected,
+            state * 2 + update * 3 + torch.tensor([1.0, -2.0]),
+        ]
+    )
+    torch.testing.assert_close(batched["state"], expected_batch)
+
+
+def test_runner_validates_names_shapes_and_batching(continuous_bundle) -> None:
+    path, _report = continuous_bundle
+    runner = ContinuousRunner.from_pretrained(path)
+    state = torch.zeros(_N_POSITIONS, 2)
+    update = torch.zeros(_N_POSITIONS, 2)
+
+    with pytest.raises(ValueError, match="missing"):
+        runner(state=state)
+    with pytest.raises(ValueError, match="unexpected"):
+        runner(state=state, update=update, extra=update)
+    with pytest.raises(ValueError, match="end in shape"):
+        runner(state=torch.zeros(2, 2), update=update)
+    with pytest.raises(ValueError, match="consistent batching"):
+        runner(state=state.unsqueeze(0), update=update)
+
+
+def test_run_until_feeds_state_output_into_fresh_invocation(continuous_bundle) -> None:
+    path, _report = continuous_bundle
+    runner = ContinuousRunner.from_pretrained(path)
+    state = torch.zeros(_N_POSITIONS, 2)
+    update = torch.ones(_N_POSITIONS, 2)
+
+    result = runner.run_until(state, max_steps=5, update=update)
+
+    torch.testing.assert_close(
+        result["state"], state + update + torch.tensor([1.0, -2.0])
+    )

--- a/tests/hf/test_custom_continuous_inputs.py
+++ b/tests/hf/test_custom_continuous_inputs.py
@@ -1,5 +1,7 @@
 """Continuous-input and raw-residual behavior of the custom HF model."""
 
+from typing import Any, Literal, cast
+
 import pytest
 import torch
 
@@ -9,7 +11,9 @@ from torchwright.compiler.hf import (
 )
 
 
-def _model() -> TorchwrightCustomForCausalLM:
+def _model(
+    *, activation: Literal["relu", "swish"] = "relu"
+) -> TorchwrightCustomForCausalLM:
     config = TorchwrightCustomConfig(
         d=8,
         d_head=4,
@@ -19,6 +23,7 @@ def _model() -> TorchwrightCustomForCausalLM:
         d_hidden_per_layer=[8],
         max_position_embeddings=4,
         rms_norm=True,
+        activation=activation,
     )
     return TorchwrightCustomForCausalLM(config).float().eval()
 
@@ -60,3 +65,28 @@ def test_inputs_embeds_validates_exclusive_source_and_shape() -> None:
         model.model(input_ids=ids, inputs_embeds=torch.zeros(1, 1, 8))
     with pytest.raises(ValueError, match="shape"):
         model.model(inputs_embeds=torch.zeros(1, 1, 7))
+
+
+def test_swiglu_model_uses_gated_mlp() -> None:
+    """The custom checkpoint model executes its configured SwiGLU equation."""
+    model = _model(activation="swish")
+    mlp = model.model.layers[0].mlp
+    assert mlp.fc1 is None
+    assert mlp.fc2 is None
+    assert mlp.gate_proj is not None
+    assert mlp.up_proj is not None
+    assert mlp.down_proj is not None
+
+    x = torch.randn(2, 3, model.config.d)
+    with torch.no_grad():
+        expected = mlp.down_proj(
+            torch.nn.functional.silu(mlp.gate_proj(x)) * mlp.up_proj(x)
+        )
+        actual = mlp(x)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_custom_config_rejects_unknown_activation() -> None:
+    with pytest.raises(ValueError, match="activation"):
+        _model(activation=cast("Any", "gelu"))

--- a/tests/hf/test_custom_continuous_inputs.py
+++ b/tests/hf/test_custom_continuous_inputs.py
@@ -1,0 +1,62 @@
+"""Continuous-input and raw-residual behavior of the custom HF model."""
+
+import pytest
+import torch
+
+from torchwright.compiler.hf import (
+    TorchwrightCustomConfig,
+    TorchwrightCustomForCausalLM,
+)
+
+
+def _model() -> TorchwrightCustomForCausalLM:
+    config = TorchwrightCustomConfig(
+        d=8,
+        d_head=4,
+        vocab_size=3,
+        n_layers=1,
+        n_heads_per_layer=[1],
+        d_hidden_per_layer=[8],
+        max_position_embeddings=4,
+        rms_norm=True,
+    )
+    return TorchwrightCustomForCausalLM(config).float().eval()
+
+
+def test_inputs_embeds_matches_embedding_lookup() -> None:
+    """The continuous hidden-state path follows the HF inputs_embeds contract."""
+    model = _model()
+    input_ids = torch.tensor([[0, 1, 2]])
+    inputs_embeds = model.model.embed_tokens(input_ids)
+
+    with torch.no_grad():
+        from_ids = model(input_ids=input_ids).logits
+        from_embeds = model(inputs_embeds=inputs_embeds).logits
+
+    torch.testing.assert_close(from_embeds, from_ids)
+
+
+def test_forward_residual_bypasses_final_norm_and_lm_head() -> None:
+    """Raw output is exactly the decoder-block result before token readout."""
+    model = _model()
+    inputs_embeds = torch.randn(2, 3, model.config.d)
+
+    with torch.no_grad():
+        raw = model.forward_residual(inputs_embeds=inputs_embeds)
+        normalized = model.model(inputs_embeds=inputs_embeds).last_hidden_state
+
+    assert raw.shape == inputs_embeds.shape
+    torch.testing.assert_close(normalized, model.model.norm(raw))
+    assert not torch.equal(raw, normalized)
+
+
+def test_inputs_embeds_validates_exclusive_source_and_shape() -> None:
+    model = _model()
+    ids = torch.tensor([[0]])
+
+    with pytest.raises(ValueError, match="exactly one"):
+        model.model()
+    with pytest.raises(ValueError, match="not both"):
+        model.model(input_ids=ids, inputs_embeds=torch.zeros(1, 1, 8))
+    with pytest.raises(ValueError, match="shape"):
+        model.model(inputs_embeds=torch.zeros(1, 1, 7))

--- a/torchwright/__init__.py
+++ b/torchwright/__init__.py
@@ -1,6 +1,7 @@
 """torchwright: a compiler from computation graphs to transformer weights.
 
-The four compile/load entry points are re-exported here, loaded lazily so
+The compile/load entry points and continuous runner are re-exported here,
+loaded lazily so
 ``import torchwright`` stays light and the base install never pulls the
 optional ``transformers`` dependency.  Op libraries are deliberately not
 re-exported: the import path (``torchwright.ops.relu`` vs
@@ -8,6 +9,8 @@ re-exported: the import path (``torchwright.ops.relu`` vs
 """
 
 __all__ = [
+    "ContinuousRunner",
+    "compile_continuous_hf_bundle",
     "compile_headless",
     "compile_hf_bundle",
     "compile_to_onnx",

--- a/torchwright/compiler/__init__.py
+++ b/torchwright/compiler/__init__.py
@@ -2,8 +2,13 @@
 
 __all__ = [
     "CompileProfile",
+    "ContinuousHFBundleReport",
+    "ContinuousIOSpec",
+    "ContinuousRunner",
+    "ContinuousValueSpec",
     "HFBundleReport",
     "ScheduleProvenance",
+    "compile_continuous_hf_bundle",
     "compile_headless",
     "compile_hf_bundle",
     "compile_to_hf",
@@ -27,6 +32,10 @@ def __getattr__(name: str) -> object:
             from . import onnx_load
 
             return onnx_load.load_onnx
+        if name.startswith("Continuous") or name == "compile_continuous_hf_bundle":
+            from .hf import continuous
+
+            return getattr(continuous, name)
         from .hf import build
 
         return getattr(build, name)

--- a/torchwright/compiler/hf/__init__.py
+++ b/torchwright/compiler/hf/__init__.py
@@ -29,6 +29,16 @@ from .build import (
     save_hf_bundle,
 )
 from .configuration_torchwright_custom import TorchwrightCustomConfig
+from .continuous import (
+    CONTINUOUS_BASE_FILENAME,
+    CONTINUOUS_IO_FILENAME,
+    CONTINUOUS_IO_FORMAT,
+    ContinuousHFBundleReport,
+    ContinuousIOSpec,
+    ContinuousRunner,
+    ContinuousValueSpec,
+    compile_continuous_hf_bundle,
+)
 from .modeling_torchwright_custom import (
     TorchwrightCustomForCausalLM,
     TorchwrightCustomModel,
@@ -37,7 +47,14 @@ from .modeling_torchwright_custom import (
 from .tokenization_torchwright_custom import TorchwrightCustomTokenizer
 
 __all__ = [
+    "CONTINUOUS_BASE_FILENAME",
+    "CONTINUOUS_IO_FILENAME",
+    "CONTINUOUS_IO_FORMAT",
     "CompileProfile",
+    "ContinuousHFBundleReport",
+    "ContinuousIOSpec",
+    "ContinuousRunner",
+    "ContinuousValueSpec",
     "HFArchitecture",
     "HFBundleReport",
     "ScheduleProvenance",
@@ -47,6 +64,7 @@ __all__ = [
     "TorchwrightCustomPreTrainedModel",
     "TorchwrightCustomTokenizer",
     "build_fast_tokenizer",
+    "compile_continuous_hf_bundle",
     "compile_hf_bundle",
     "compile_to_hf",
     "save_hf_bundle",

--- a/torchwright/compiler/hf/build.py
+++ b/torchwright/compiler/hf/build.py
@@ -500,18 +500,39 @@ class _DirectShardSink:
         a = layer.attention
         p = f"model.layers.{index}"
         if self._profile is CompileProfile.CUSTOM:
-            assert isinstance(layer, ReluLayerWeights)
             sd = {
                 f"{p}.self_attn.q_proj.weight": _torch(a.wq).T.contiguous(),
                 f"{p}.self_attn.k_proj.weight": _torch(a.wk).T.contiguous(),
                 f"{p}.self_attn.v_proj.weight": _torch(a.wv).T.contiguous(),
                 f"{p}.self_attn.o_proj.weight": _torch(a.wo).T.contiguous(),
-                f"{p}.mlp.fc1.weight": _torch(layer.w1).T.contiguous(),
-                f"{p}.mlp.fc1.bias": _torch(cast("np.ndarray", layer.b1)),
-                f"{p}.mlp.fc2.weight": _torch(layer.w2).T.contiguous(),
-                f"{p}.mlp.fc2.bias": _torch(cast("np.ndarray", layer.b2)),
             }
-            kind = "relu"
+            if isinstance(layer, ReluLayerWeights):
+                sd.update(
+                    {
+                        f"{p}.mlp.fc1.weight": _torch(layer.w1).T.contiguous(),
+                        f"{p}.mlp.fc1.bias": _torch(cast("np.ndarray", layer.b1)),
+                        f"{p}.mlp.fc2.weight": _torch(layer.w2).T.contiguous(),
+                        f"{p}.mlp.fc2.bias": _torch(cast("np.ndarray", layer.b2)),
+                    }
+                )
+                kind = "relu"
+            else:
+                assert isinstance(layer, SwishLayerWeights)
+                sd.update(
+                    {
+                        f"{p}.mlp.gate_proj.weight": _torch(layer.wgate).T.contiguous(),
+                        f"{p}.mlp.gate_proj.bias": _torch(
+                            cast("np.ndarray", layer.bgate)
+                        ),
+                        f"{p}.mlp.up_proj.weight": _torch(layer.wup).T.contiguous(),
+                        f"{p}.mlp.up_proj.bias": _torch(cast("np.ndarray", layer.bup)),
+                        f"{p}.mlp.down_proj.weight": _torch(layer.wdown).T.contiguous(),
+                        f"{p}.mlp.down_proj.bias": _torch(
+                            cast("np.ndarray", layer.bdown)
+                        ),
+                    }
+                )
+                kind = "swish"
         else:
             assert isinstance(layer, SwishLayerWeights)
             rows, inter = self.max_heads * d_head, self.max_hidden
@@ -1315,6 +1336,7 @@ def _compile_hf_bundle_into(
                 d_rot=d_rot,
                 rms_norm=spec.rms_norm,
                 rms_norm_eps=spec.rms_norm_eps,
+                activation="relu",
                 bos_token_id=bos_id,
                 eos_token_id=eos_id,
                 # token.v6: the custom model's lm_head is storage-tied to

--- a/torchwright/compiler/hf/build.py
+++ b/torchwright/compiler/hf/build.py
@@ -467,7 +467,12 @@ class _DirectShardSink:
     """Streams each compiled layer directly into its final HF shard."""
 
     def __init__(
-        self, profile: CompileProfile, d_head: int, output_dir: str | os.PathLike
+        self,
+        profile: CompileProfile,
+        d_head: int,
+        output_dir: str | os.PathLike,
+        *,
+        capture_support: bool = True,
     ) -> None:
         self._profile = profile
         self._d_head = d_head
@@ -477,6 +482,7 @@ class _DirectShardSink:
         self.total_size = 0
         self.support_array_paths: dict[str, Path] = {}
         self.support_tensors: dict[str, dict[str, Any]] = {}
+        self._capture_support = capture_support
 
     def begin(self, header: CompileHeader) -> None:
         self.header = header
@@ -545,6 +551,8 @@ class _DirectShardSink:
         """Capture exact nonzero coordinates without materializing a full mask."""
         import torch
 
+        if not self._capture_support:
+            return
         max_chunk_elements = 1 << 20
         for name, value in state_dict.items():
             prefix = f"tensor_{len(self.support_tensors):06d}"

--- a/torchwright/compiler/hf/configuration_torchwright_custom.py
+++ b/torchwright/compiler/hf/configuration_torchwright_custom.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from transformers import PretrainedConfig
 
@@ -14,10 +14,12 @@ class TorchwrightCustomConfig(PretrainedConfig):
     ``(vocab_size, d)`` token embedding feeds ``n_layers`` attention+MLP
     blocks, and the same ``(vocab_size, d)`` table is tied to ``lm_head`` for
     readout. Attention is causal with ``scale=1.0`` and rotary position
-    embeddings; the MLP is ``fc2(relu(fc1(x)))``. Head count and MLP hidden
-    width may vary per layer. When ``rms_norm`` is set, each sublayer input
-    and the final hidden state pass through a Llama-style RMSNorm. Weights
-    and activations are fp32; the modeling code enforces this.
+    embeddings. The MLP is either biased ReLU
+    ``fc2(relu(fc1(x)))`` or biased SwiGLU
+    ``down(swish(gate(x)) * up(x))``. Head count and MLP hidden width may vary
+    per layer. When ``rms_norm`` is set, each sublayer input and the final hidden
+    state pass through a Llama-style RMSNorm. Weights and activations are fp32;
+    the modeling code enforces this.
 
     Args:
         d: Residual stream width (also the embedding/unembedding width).
@@ -37,6 +39,7 @@ class TorchwrightCustomConfig(PretrainedConfig):
         rms_norm: Whether the model applies RMSNorm — pre-norm on each
             sublayer input plus a final norm.
         rms_norm_eps: RMSNorm epsilon.
+        activation: Physical MLP machine, ``"relu"`` or ``"swish"``.
     """
 
     model_type = "torchwright_custom"
@@ -55,6 +58,7 @@ class TorchwrightCustomConfig(PretrainedConfig):
         *,
         rms_norm: bool = False,
         rms_norm_eps: float = 1e-5,
+        activation: Literal["relu", "swish"] = "relu",
         **kwargs: object,
     ) -> None:
         self.d = int(d)
@@ -75,6 +79,12 @@ class TorchwrightCustomConfig(PretrainedConfig):
             )
         self.rms_norm = bool(rms_norm)
         self.rms_norm_eps = float(rms_norm_eps)
+        if activation not in ("relu", "swish"):
+            raise ValueError(
+                "TorchwrightCustomConfig.activation must be 'relu' or 'swish'; "
+                f"got {activation!r}."
+            )
+        self.activation = activation
         # Canonical aliases consulted by generic transformers utilities (cache
         # sizing, repr, sharding). Recomputed from our own fields; drop any
         # stale values round-tripped in from a serialized config.

--- a/torchwright/compiler/hf/continuous.py
+++ b/torchwright/compiler/hf/continuous.py
@@ -13,7 +13,7 @@ import json
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import torch
 from safetensors.torch import load_file, save_file
@@ -218,8 +218,8 @@ def _write_continuous_final_shard(
         state_dict["model.norm.weight"] = gain
         for index in range(n_layers):
             prefix = f"model.layers.{index}"
-            state_dict[f"{prefix}.input_layernorm.weight"] = gain
-            state_dict[f"{prefix}.post_attention_layernorm.weight"] = gain
+            state_dict[f"{prefix}.input_layernorm.weight"] = gain.clone()
+            state_dict[f"{prefix}.post_attention_layernorm.weight"] = gain.clone()
     filename = f"model-{shard_count:05d}-of-{shard_count:05d}.safetensors"
     save_file(state_dict, str(Path(output_dir) / filename))
     weight_map = dict(sink.weight_map)
@@ -269,6 +269,7 @@ def compile_continuous_hf_bundle(
     rms_norm: bool = False,
     rms_norm_eps: float = 1e-5,
     rms_norm_const_exp: int | None = None,
+    machine: Literal["relu", "swish"] | None = None,
     verbose: bool = False,
     _solver_seed: int | None = None,
     _force_resolve: bool = False,
@@ -277,14 +278,17 @@ def compile_continuous_hf_bundle(
 
     ``n_positions`` fixes the sequence dimension stored in the bundle. Runtime
     values may be unbatched ``(n_positions, width)`` tensors or consistently
-    batched ``(batch, n_positions, width)`` tensors. The continuous profile
-    uses the custom biased-ReLU decoder and never requires a token embedding in
-    the source graph.
+    batched ``(batch, n_positions, width)`` tensors. ``machine`` may pin the
+    custom biased-ReLU or biased-SwiGLU decoder and must then match the graph's
+    op library. By default the compiler infers it from the graph (with ReLU as
+    the no-FFN fallback). The source graph never requires a token embedding.
     """
     if n_positions <= 0:
         raise ValueError("n_positions must be positive")
     if rms_norm and not rms_norm_width_supported(d):
         raise ValueError(f"rms_norm is on but d={d} is unsupported")
+    if machine not in (None, "relu", "swish"):
+        raise ValueError(f"machine must be 'relu', 'swish', or None; got {machine!r}")
     outputs = _validate_outputs(outputs)
     inputs = _named_inputs(outputs)
     output_node = (
@@ -323,7 +327,7 @@ def compile_continuous_hf_bundle(
                 d_hidden=d_hidden,
                 rms_norm=rms_norm,
                 rms_norm_eps=rms_norm_eps,
-                machine="relu",
+                machine=machine,
                 _solver_seed=_solver_seed,
                 _force_resolve=_force_resolve,
                 **cast(
@@ -385,6 +389,7 @@ def compile_continuous_hf_bundle(
                 d_rot=d_rot,
                 rms_norm=rms_spec is not None,
                 rms_norm_eps=rms_spec.eps if rms_spec is not None else rms_norm_eps,
+                activation=cast("Literal['relu', 'swish']", compiled.activation),
                 bos_token_id=None,
                 eos_token_id=None,
             )

--- a/torchwright/compiler/hf/continuous.py
+++ b/torchwright/compiler/hf/continuous.py
@@ -1,0 +1,582 @@
+"""Continuous-input Hugging Face export and runtime support.
+
+The exporter compiles the same residual-stream transformer used by
+``HeadlessTransformer``.  A sidecar safetensors file stores the compiler-built
+initial residual, including literal values and pinned normalization constants.
+The runtime clones that tensor, overwrites named ``InputNode`` columns, runs the
+decoder blocks, and reads named graph outputs from the raw final residual.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import torch
+from safetensors.torch import load_file, save_file
+
+from torchwright.compiler.forward.compile import (
+    forward_compile,
+    rms_norm_width_supported,
+)
+from torchwright.compiler.token_model import (
+    CompileHeader,
+    CompileProfile,
+    ScheduleProvenance,
+    make_layer_callback,
+    resolve_rope,
+    schedule_provenance,
+)
+from torchwright.compiler.utils import get_ancestor_nodes, resolve_n_heads
+from torchwright.graph import Concatenate, Embedding, InputNode, Node
+
+from .build import (
+    _copy_custom_code,
+    _DirectShardSink,
+    _rope_proxy_layers,
+    _staged_bundle_directory,
+    _validate_staged_bundle,
+)
+from .configuration_torchwright_custom import TorchwrightCustomConfig
+from .modeling_torchwright_custom import TorchwrightCustomForCausalLM
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+CONTINUOUS_IO_FORMAT = "torchwright_continuous_io_v1"
+CONTINUOUS_IO_FILENAME = "continuous_io.json"
+CONTINUOUS_BASE_FILENAME = "continuous_io.safetensors"
+_BASE_RESIDUAL_KEY = "base_residual"
+_UNBATCHED_NDIM = 2
+_BATCHED_NDIM = 3
+
+
+@dataclass(frozen=True)
+class ContinuousValueSpec:
+    """One named continuous value's shape and residual placement."""
+
+    width: int
+    shape: list[int]
+    batched_shape: list[int | str]
+    residual_columns: list[int]
+    dtype: str = "float32"
+
+
+@dataclass(frozen=True)
+class ContinuousIOSpec:
+    """Versioned continuous interface persisted beside an HF checkpoint."""
+
+    format: str
+    n_positions: int
+    d_model: int
+    inputs: dict[str, ContinuousValueSpec]
+    outputs: dict[str, ContinuousValueSpec]
+    base_residual: dict[str, str | list[int]]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON representation written into a bundle."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> ContinuousIOSpec:
+        """Parse and validate a persisted interface specification."""
+        if value.get("format") != CONTINUOUS_IO_FORMAT:
+            raise ValueError(
+                f"unsupported continuous I/O format: {value.get('format')!r}"
+            )
+
+        def values(section: str) -> dict[str, ContinuousValueSpec]:
+            raw = value.get(section)
+            if not isinstance(raw, dict):
+                raise TypeError(f"continuous I/O {section} must be an object")
+            parsed = {}
+            for name, item in raw.items():
+                if not isinstance(name, str) or not isinstance(item, dict):
+                    raise TypeError(f"invalid continuous I/O {section} entry")
+                parsed[name] = ContinuousValueSpec(
+                    width=int(item["width"]),
+                    shape=[int(dim) for dim in item["shape"]],
+                    batched_shape=[
+                        dim if isinstance(dim, str) else int(dim)
+                        for dim in item["batched_shape"]
+                    ],
+                    residual_columns=[int(col) for col in item["residual_columns"]],
+                    dtype=str(item["dtype"]),
+                )
+            return parsed
+
+        base = value.get("base_residual")
+        if not isinstance(base, dict):
+            raise TypeError("continuous I/O base_residual must be an object")
+        spec = cls(
+            format=CONTINUOUS_IO_FORMAT,
+            n_positions=int(value["n_positions"]),
+            d_model=int(value["d_model"]),
+            inputs=values("inputs"),
+            outputs=values("outputs"),
+            base_residual=cast("dict[str, str | list[int]]", dict(base)),
+        )
+        spec.validate()
+        return spec
+
+    def validate(self) -> None:
+        """Validate dimensions, dtypes, shapes, and residual columns."""
+        if self.n_positions <= 0 or self.d_model <= 0:
+            raise ValueError("continuous I/O dimensions must be positive")
+        if not self.inputs or not self.outputs:
+            raise ValueError("continuous I/O requires at least one input and output")
+        for section in (self.inputs, self.outputs):
+            for name, item in section.items():
+                self._validate_value(name, item)
+
+    def _validate_value(self, name: str, item: ContinuousValueSpec) -> None:
+        if not name:
+            raise ValueError("continuous I/O names must not be empty")
+        if item.dtype != "float32":
+            raise ValueError(f"unsupported continuous dtype {item.dtype!r}")
+        if item.shape != [self.n_positions, item.width]:
+            raise ValueError(f"invalid shape metadata for {name!r}")
+        if item.batched_shape != ["batch", self.n_positions, item.width]:
+            raise ValueError(f"invalid batched shape metadata for {name!r}")
+        if len(item.residual_columns) != item.width:
+            raise ValueError(f"invalid residual columns for {name!r}")
+        if any(col < 0 or col >= self.d_model for col in item.residual_columns):
+            raise ValueError(f"residual column out of range for {name!r}")
+
+
+@dataclass(frozen=True)
+class ContinuousHFBundleReport:
+    """Small result describing a published continuous HF bundle."""
+
+    output_dir: str | os.PathLike[str]
+    n_layers: int
+    n_positions: int
+    schedule_provenance: ScheduleProvenance
+
+
+def _named_inputs(outputs: Mapping[str, Node]) -> dict[str, InputNode]:
+    found = [
+        node
+        for node in get_ancestor_nodes(set(outputs.values()))
+        if isinstance(node, InputNode)
+    ]
+    named: dict[str, InputNode] = {}
+    for node in sorted(found, key=lambda item: item.node_id):
+        if not node.name:
+            raise ValueError("continuous HF inputs must have non-empty names")
+        if node.name in named and named[node.name] is not node:
+            raise ValueError(f"continuous HF input name is duplicated: {node.name!r}")
+        named[node.name] = node
+    if not named:
+        raise ValueError("continuous HF compilation requires at least one InputNode")
+    return named
+
+
+def _validate_outputs(outputs: Mapping[str, Node]) -> dict[str, Node]:
+    if not outputs:
+        raise ValueError("outputs must contain at least one named Node")
+    validated = {}
+    for name, node in outputs.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError("continuous HF output names must be non-empty strings")
+        if not isinstance(node, Node):
+            raise TypeError(f"continuous HF output {name!r} is not a Node")
+        validated[name] = node
+    ancestors = get_ancestor_nodes(set(validated.values()))
+    if any(isinstance(node, Embedding) for node in ancestors):
+        raise ValueError("continuous HF graphs cannot contain token Embedding nodes")
+    return validated
+
+
+def _value_spec(
+    node: Node, columns: list[int], n_positions: int
+) -> ContinuousValueSpec:
+    return ContinuousValueSpec(
+        width=node.d_output,
+        shape=[n_positions, node.d_output],
+        batched_shape=["batch", n_positions, node.d_output],
+        residual_columns=list(columns),
+    )
+
+
+def _write_continuous_final_shard(
+    output_dir: str | os.PathLike[str],
+    *,
+    d: int,
+    n_layers: int,
+    rms_gain: float | None,
+    sink: _DirectShardSink,
+) -> None:
+    """Write structural embedding/norm weights and the shard index."""
+    shard_count = n_layers + 1
+    state_dict = {"model.embed_tokens.weight": torch.zeros((1, d))}
+    if rms_gain is not None:
+        gain = torch.full((d,), rms_gain)
+        state_dict["model.norm.weight"] = gain
+        for index in range(n_layers):
+            prefix = f"model.layers.{index}"
+            state_dict[f"{prefix}.input_layernorm.weight"] = gain
+            state_dict[f"{prefix}.post_attention_layernorm.weight"] = gain
+    filename = f"model-{shard_count:05d}-of-{shard_count:05d}.safetensors"
+    save_file(state_dict, str(Path(output_dir) / filename))
+    weight_map = dict(sink.weight_map)
+    total_size = sink.total_size
+    for name, tensor in state_dict.items():
+        weight_map[name] = filename
+        total_size += tensor.numel() * tensor.element_size()
+    manifest = {"metadata": {"total_size": total_size}, "weight_map": weight_map}
+    (Path(output_dir) / "model.safetensors.index.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
+
+def _validate_continuous_bundle(directory: str | os.PathLike[str]) -> None:
+    path = Path(directory)
+    config = json.loads((path / "config.json").read_text(encoding="utf-8"))
+    expected_pointer = {
+        "format": CONTINUOUS_IO_FORMAT,
+        "spec": CONTINUOUS_IO_FILENAME,
+        "base_residual": CONTINUOUS_BASE_FILENAME,
+    }
+    if config.get("torchwright_continuous_io") != expected_pointer:
+        raise RuntimeError("config.json continuous I/O pointer is missing or invalid")
+    spec = ContinuousIOSpec.from_dict(
+        json.loads((path / CONTINUOUS_IO_FILENAME).read_text(encoding="utf-8"))
+    )
+    tensors = load_file(path / CONTINUOUS_BASE_FILENAME, device="cpu")
+    base = tensors.get(_BASE_RESIDUAL_KEY)
+    if base is None or list(base.shape) != [spec.n_positions, spec.d_model]:
+        raise RuntimeError("continuous base residual shape does not match its spec")
+    if base.dtype != torch.float32:
+        raise RuntimeError("continuous base residual must be float32")
+
+
+def compile_continuous_hf_bundle(
+    outputs: Mapping[str, Node],
+    output_dir: str | os.PathLike[str],
+    *,
+    n_positions: int,
+    d: int = 1024,
+    d_head: int = 16,
+    n_heads: int | None = None,
+    max_layers: int = 400,
+    optimize: int = 0,
+    d_hidden: int | None = None,
+    trim_heads: bool = True,
+    rms_norm: bool = False,
+    rms_norm_eps: float = 1e-5,
+    rms_norm_const_exp: int | None = None,
+    verbose: bool = False,
+    _solver_seed: int | None = None,
+    _force_resolve: bool = False,
+) -> ContinuousHFBundleReport:
+    """Compile named tensor outputs into a continuous Hugging Face bundle.
+
+    ``n_positions`` fixes the sequence dimension stored in the bundle. Runtime
+    values may be unbatched ``(n_positions, width)`` tensors or consistently
+    batched ``(batch, n_positions, width)`` tensors. The continuous profile
+    uses the custom biased-ReLU decoder and never requires a token embedding in
+    the source graph.
+    """
+    if n_positions <= 0:
+        raise ValueError("n_positions must be positive")
+    if rms_norm and not rms_norm_width_supported(d):
+        raise ValueError(f"rms_norm is on but d={d} is unsupported")
+    outputs = _validate_outputs(outputs)
+    inputs = _named_inputs(outputs)
+    output_node = (
+        next(iter(outputs.values()))
+        if len(outputs) == 1
+        else Concatenate(list(outputs.values()))
+    )
+    n_heads = resolve_n_heads(d, d_head, n_heads)
+
+    with _staged_bundle_directory(output_dir) as staging:
+        sink = _DirectShardSink(
+            CompileProfile.CUSTOM, d_head, staging, capture_support=False
+        )
+        with torch.no_grad():
+            compiled = forward_compile(
+                d=d,
+                d_head=d_head,
+                n_heads=n_heads,
+                output_node=output_node,
+                verbose=verbose,
+                max_layers=max_layers,
+                device=None,
+                on_layer_compiled=make_layer_callback(
+                    CompileHeader(
+                        d=d,
+                        d_head=d_head,
+                        trim_heads=trim_heads,
+                        bias=True,
+                        n_heads=n_heads,
+                    ),
+                    sink,
+                ),
+                trim_heads=trim_heads,
+                optimize=optimize,
+                bias=True,
+                d_hidden=d_hidden,
+                rms_norm=rms_norm,
+                rms_norm_eps=rms_norm_eps,
+                machine="relu",
+                _solver_seed=_solver_seed,
+                _force_resolve=_force_resolve,
+                **cast(
+                    "dict[str, Any]",
+                    {}
+                    if rms_norm_const_exp is None
+                    else {"rms_norm_const_exp": rms_norm_const_exp},
+                ),
+            )
+            assignment = compiled.residual_assignment
+            if assignment is None or not compiled.layers:
+                raise RuntimeError("continuous compilation produced no residual states")
+            input_state = compiled.layers[0].attn.in_state
+            output_state = compiled.layers[-1].mlp.out_state
+            zero_inputs = {
+                name: torch.zeros((n_positions, node.d_output))
+                for name, node in inputs.items()
+            }
+            base_residual = compiled.get_input_res_stream(n_positions, zero_inputs)
+            input_specs = {
+                name: _value_spec(
+                    node, assignment.get_node_indices(input_state, node), n_positions
+                )
+                for name, node in inputs.items()
+            }
+            output_specs = {
+                name: _value_spec(
+                    node, assignment.get_node_indices(output_state, node), n_positions
+                )
+                for name, node in outputs.items()
+            }
+            spec = ContinuousIOSpec(
+                format=CONTINUOUS_IO_FORMAT,
+                n_positions=n_positions,
+                d_model=d,
+                inputs=input_specs,
+                outputs=output_specs,
+                base_residual={
+                    "file": CONTINUOUS_BASE_FILENAME,
+                    "tensor": _BASE_RESIDUAL_KEY,
+                    "dtype": "float32",
+                    "shape": [n_positions, d],
+                },
+            )
+            spec.validate()
+            heads = [item[1] for item in sink.meta]
+            hidden = [item[2] for item in sink.meta]
+            rope_base, d_rot = resolve_rope(_rope_proxy_layers(sink.meta), d_head)
+            rms_spec = compiled.rms_norm_spec
+            config = TorchwrightCustomConfig(
+                d=d,
+                d_head=d_head,
+                vocab_size=1,
+                n_layers=len(sink.meta),
+                n_heads_per_layer=heads,
+                d_hidden_per_layer=hidden,
+                max_position_embeddings=n_positions,
+                rope_base=rope_base,
+                d_rot=d_rot,
+                rms_norm=rms_spec is not None,
+                rms_norm_eps=rms_spec.eps if rms_spec is not None else rms_norm_eps,
+                bos_token_id=None,
+                eos_token_id=None,
+            )
+            config.architectures = ["TorchwrightCustomForCausalLM"]
+            config.auto_map = {
+                "AutoConfig": (
+                    "configuration_torchwright_custom.TorchwrightCustomConfig"
+                ),
+                "AutoModelForCausalLM": (
+                    "modeling_torchwright_custom.TorchwrightCustomForCausalLM"
+                ),
+            }
+            config.torchwright_continuous_io = {
+                "format": CONTINUOUS_IO_FORMAT,
+                "spec": CONTINUOUS_IO_FILENAME,
+                "base_residual": CONTINUOUS_BASE_FILENAME,
+            }
+            config.save_pretrained(staging)
+            _write_continuous_final_shard(
+                staging,
+                d=d,
+                n_layers=len(sink.meta),
+                rms_gain=None if rms_spec is None else rms_spec.gain,
+                sink=sink,
+            )
+            save_file(
+                {_BASE_RESIDUAL_KEY: base_residual},
+                Path(staging) / CONTINUOUS_BASE_FILENAME,
+            )
+            (Path(staging) / CONTINUOUS_IO_FILENAME).write_text(
+                json.dumps(spec.to_dict(), indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            provenance = schedule_provenance(compiled, optimize)
+        _copy_custom_code(staging)
+        _validate_staged_bundle(staging, expect_tokenizer=False)
+        _validate_continuous_bundle(staging)
+
+    return ContinuousHFBundleReport(
+        output_dir=output_dir,
+        n_layers=len(sink.meta),
+        n_positions=n_positions,
+        schedule_provenance=provenance,
+    )
+
+
+def _resolve_pretrained_path(path_or_repo_id: str | os.PathLike[str]) -> Path:
+    path = Path(path_or_repo_id)
+    if path.exists():
+        return path
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(repo_id=os.fspath(path_or_repo_id)))
+
+
+class ContinuousRunner:
+    """Named tensor runtime for a compiled continuous HF bundle."""
+
+    def __init__(
+        self,
+        model: TorchwrightCustomForCausalLM,
+        spec: ContinuousIOSpec,
+        base_residual: torch.Tensor,
+    ) -> None:
+        self.model = model
+        self.spec = spec
+        self.base_residual = base_residual
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        path_or_repo_id: str | os.PathLike[str],
+        *,
+        device: str | torch.device | None = None,
+    ) -> ContinuousRunner:
+        """Load a local bundle or Hugging Face Hub repository."""
+        path = _resolve_pretrained_path(path_or_repo_id)
+        _validate_continuous_bundle(path)
+        spec = ContinuousIOSpec.from_dict(
+            json.loads((path / CONTINUOUS_IO_FILENAME).read_text(encoding="utf-8"))
+        )
+        base = load_file(path / CONTINUOUS_BASE_FILENAME, device="cpu")[
+            _BASE_RESIDUAL_KEY
+        ]
+        model = TorchwrightCustomForCausalLM.from_pretrained(path).float().eval()
+        if device is not None:
+            model = model.to(device)
+            base = base.to(device)
+        return cls(model, spec, base)
+
+    @property
+    def device(self) -> torch.device:
+        """Device holding the model and constructed residual streams."""
+        return next(self.model.parameters()).device
+
+    def _inputs(
+        self, values: Mapping[str, torch.Tensor]
+    ) -> tuple[dict[str, torch.Tensor], int, bool]:
+        expected, actual = set(self.spec.inputs), set(values)
+        if missing := sorted(expected - actual):
+            raise ValueError(f"missing continuous inputs: {missing}")
+        if unexpected := sorted(actual - expected):
+            raise ValueError(f"unexpected continuous inputs: {unexpected}")
+        normalized = {}
+        batched: bool | None = None
+        batch_size: int | None = None
+        for name, item in self.spec.inputs.items():
+            value = values[name]
+            if not isinstance(value, torch.Tensor):
+                raise TypeError(f"continuous input {name!r} must be a torch.Tensor")
+            if value.ndim not in (_UNBATCHED_NDIM, _BATCHED_NDIM):
+                raise ValueError(
+                    f"continuous input {name!r} must have 2 or 3 dimensions"
+                )
+            this_batched = value.ndim == _BATCHED_NDIM
+            if batched is not None and this_batched != batched:
+                raise ValueError("continuous inputs must use consistent batching")
+            batched = this_batched
+            expected_tail = (self.spec.n_positions, item.width)
+            if tuple(value.shape[-2:]) != expected_tail:
+                raise ValueError(
+                    f"continuous input {name!r} must end in shape {expected_tail}; "
+                    f"got {tuple(value.shape)}"
+                )
+            if this_batched:
+                if batch_size is not None and value.shape[0] != batch_size:
+                    raise ValueError("continuous inputs must have one batch size")
+                batch_size = value.shape[0]
+            normalized[name] = value.to(device=self.device, dtype=torch.float32)
+        return normalized, 1 if batch_size is None else batch_size, bool(batched)
+
+    def __call__(self, **inputs: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Run one fresh continuous state transition with no KV-cache history."""
+        values, batch_size, batched = self._inputs(inputs)
+        residual = (
+            self.base_residual.to(self.device)
+            .unsqueeze(0)
+            .expand(batch_size, -1, -1)
+            .clone()
+        )
+        for name, item in self.spec.inputs.items():
+            value = values[name] if batched else values[name].unsqueeze(0)
+            residual[..., item.residual_columns] = value
+        with torch.no_grad():
+            raw = self.model.forward_residual(inputs_embeds=residual, use_cache=False)
+        outputs = {
+            name: raw[..., item.residual_columns]
+            for name, item in self.spec.outputs.items()
+        }
+        if batched:
+            return outputs
+        return {name: value.squeeze(0) for name, value in outputs.items()}
+
+    def run_until(
+        self,
+        initial_state: torch.Tensor,
+        *,
+        state_input: str = "state",
+        state_output: str = "state",
+        stop_output: str = "converged",
+        max_steps: int,
+        stop_when: Callable[[torch.Tensor], bool] | None = None,
+        **static_inputs: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """Apply fresh transitions until the model's stop output is true.
+
+        The default considers the model finished when every value in
+        ``stop_output`` is greater than zero. ``stop_when`` can replace that
+        reduction without moving application-specific numerical work into the
+        recurrent loop. The returned mapping is the final invocation's output.
+        """
+        if max_steps <= 0:
+            raise ValueError("max_steps must be positive")
+        state = initial_state
+        latest: dict[str, torch.Tensor] | None = None
+        predicate = stop_when or (lambda value: bool(torch.all(value > 0).item()))
+        for _step in range(max_steps):
+            latest = self(**{**static_inputs, state_input: state})
+            state = latest[state_output]
+            if predicate(latest[stop_output]):
+                break
+        assert latest is not None
+        return latest
+
+
+__all__ = [
+    "CONTINUOUS_BASE_FILENAME",
+    "CONTINUOUS_IO_FILENAME",
+    "CONTINUOUS_IO_FORMAT",
+    "ContinuousHFBundleReport",
+    "ContinuousIOSpec",
+    "ContinuousRunner",
+    "ContinuousValueSpec",
+    "compile_continuous_hf_bundle",
+]

--- a/torchwright/compiler/hf/modeling_torchwright_custom.py
+++ b/torchwright/compiler/hf/modeling_torchwright_custom.py
@@ -8,7 +8,7 @@ The forward path:
     h = embed_tokens(input_ids)                    # (B, T, d)
     for each layer:
         h = h + attn(norm(h))                      # causal, scale=1.0, RoPE, no bias
-        h = h + mlp(norm(h))                       # fc2(relu(fc1(h))), biased
+        h = h + mlp(norm(h))                       # biased ReLU or SwiGLU
     logits = lm_head(norm(h))                      # tied to embed_tokens, no bias
 
 ``norm`` is a Llama-style RMSNorm when ``config.rms_norm`` is set and
@@ -215,16 +215,34 @@ class TorchwrightCustomAttention(nn.Module):
 
 
 class TorchwrightCustomMLP(nn.Module):
-    """``fc2(relu(fc1(x)))`` — both linears biased."""
+    """Biased ReLU or SwiGLU MLP selected by ``config.activation``."""
 
     def __init__(self, config: TorchwrightCustomConfig, layer_idx: int) -> None:
         super().__init__()
         d_hidden = config.d_hidden_per_layer[layer_idx]
-        self.fc1 = nn.Linear(config.d, d_hidden, bias=True)
-        self.fc2 = nn.Linear(d_hidden, config.d, bias=True)
+        self.activation = config.activation
+        if self.activation == "relu":
+            self.fc1: nn.Module | None = nn.Linear(config.d, d_hidden, bias=True)
+            self.fc2: nn.Module | None = nn.Linear(d_hidden, config.d, bias=True)
+            self.gate_proj: nn.Module | None = None
+            self.up_proj: nn.Module | None = None
+            self.down_proj: nn.Module | None = None
+        else:
+            self.fc1 = None
+            self.fc2 = None
+            self.gate_proj = nn.Linear(config.d, d_hidden, bias=True)
+            self.up_proj = nn.Linear(config.d, d_hidden, bias=True)
+            self.down_proj = nn.Linear(d_hidden, config.d, bias=True)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.fc2(functional.relu(self.fc1(x)))
+        if self.activation == "relu":
+            assert self.fc1 is not None
+            assert self.fc2 is not None
+            return self.fc2(functional.relu(self.fc1(x)))
+        assert self.gate_proj is not None
+        assert self.up_proj is not None
+        assert self.down_proj is not None
+        return self.down_proj(functional.silu(self.gate_proj(x)) * self.up_proj(x))
 
 
 class TorchwrightCustomRMSNorm(nn.Module):

--- a/torchwright/compiler/hf/modeling_torchwright_custom.py
+++ b/torchwright/compiler/hf/modeling_torchwright_custom.py
@@ -49,6 +49,7 @@ _SDPA_BACKEND = [SDPBackend.MATH]
 
 # A supported key-padding mask is 2D: (batch, total_keys).
 _KEY_PADDING_MASK_NDIM = 2
+_HIDDEN_STATES_NDIM = 3
 
 
 def _require_fp32(hidden_states: torch.Tensor) -> None:
@@ -313,7 +314,13 @@ class TorchwrightCustomPreTrainedModel(PreTrainedModel):
 
 
 class TorchwrightCustomModel(TorchwrightCustomPreTrainedModel):
-    """Decoder trunk: token embedding, ``n_layers`` decoder blocks, final norm."""
+    """Decoder trunk: token embedding, ``n_layers`` decoder blocks, final norm.
+
+    ``forward_residual`` exposes the compiled residual stream after the decoder
+    blocks and before the token-oriented final normalization.  Continuous
+    Torchwright artifacts use that path because their output coordinates are
+    defined in the compiler's raw residual representation.
+    """
 
     def __init__(self, config: TorchwrightCustomConfig) -> None:
         super().__init__(config)
@@ -335,7 +342,7 @@ class TorchwrightCustomModel(TorchwrightCustomPreTrainedModel):
     def set_input_embeddings(self, value: nn.Module) -> None:
         self.embed_tokens = value
 
-    def forward(
+    def _forward_residual(
         self,
         input_ids: torch.LongTensor | None = None,
         attention_mask: torch.Tensor | None = None,
@@ -346,18 +353,30 @@ class TorchwrightCustomModel(TorchwrightCustomPreTrainedModel):
         use_cache: bool | None = None,
         cache_position: torch.LongTensor | None = None,
         **_kwargs: object,
-    ) -> BaseModelOutputWithPast:
-        if inputs_embeds is not None:
-            raise NotImplementedError("inputs_embeds is not supported; pass input_ids.")
-        if input_ids is None:
-            raise ValueError("TorchwrightCustomModel requires input_ids.")
+    ) -> tuple[torch.Tensor, Cache | None]:
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError(
+                "Pass exactly one of input_ids or inputs_embeds, not both."
+            )
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("Pass exactly one of input_ids or inputs_embeds.")
         # `use_cache` is a generation parameter, which transformers 5.x strips
         # off the config dataclass — read it defensively, defaulting to True
         # (a bare forward must not crash on the missing attribute).
         if use_cache is None:
             use_cache = getattr(self.config, "use_cache", True)
 
-        hidden_states = self.embed_tokens(input_ids)  # (B, T, d)
+        hidden_states = (
+            self.embed_tokens(input_ids) if inputs_embeds is None else inputs_embeds
+        )
+        if (
+            hidden_states.ndim != _HIDDEN_STATES_NDIM
+            or hidden_states.shape[-1] != self.config.d
+        ):
+            raise ValueError(
+                "inputs_embeds must have shape (batch, sequence, "
+                f"{self.config.d}); got {tuple(hidden_states.shape)}."
+            )
         _B, T = hidden_states.shape[0], hidden_states.shape[1]
         device = hidden_states.device
 
@@ -378,11 +397,61 @@ class TorchwrightCustomModel(TorchwrightCustomPreTrainedModel):
         for layer in self.layers:
             hidden_states = layer(hidden_states, mask, past_key_values, cache_position)
 
+        return hidden_states, past_key_values if use_cache else None
+
+    def forward_residual(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        *,
+        use_cache: bool | None = False,
+        cache_position: torch.LongTensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        """Return the raw residual after all compiled transformer layers."""
+        hidden_states, _past = self._forward_residual(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        return hidden_states
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        *,
+        use_cache: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+        **kwargs: object,
+    ) -> BaseModelOutputWithPast:
+        hidden_states, returned_past = self._forward_residual(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
         hidden_states = self.norm(hidden_states)
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=past_key_values if use_cache else None,
+            past_key_values=returned_past,
         )
 
 
@@ -415,6 +484,10 @@ class TorchwrightCustomForCausalLM(TorchwrightCustomPreTrainedModel, GenerationM
 
     def get_decoder(self) -> TorchwrightCustomModel:
         return self.model
+
+    def forward_residual(self, *args: object, **kwargs: object) -> torch.Tensor:
+        """Return the decoder's raw residual without normalization or readout."""
+        return self.model.forward_residual(*args, **kwargs)
 
     def forward(
         self,

--- a/torchwright/compiler/transformer.py
+++ b/torchwright/compiler/transformer.py
@@ -104,6 +104,7 @@ class HeadlessTransformer:
         self.placements = None
         self.cpsat_assignment_payload = None
         self.schematic_capture = None
+        self.rms_norm_spec = None
 
     @property
     def device(self) -> torch.device:
@@ -130,6 +131,17 @@ class HeadlessTransformer:
             self.layers = [layer, *self.layers]
         return layer
 
+    def _seed_rms_norm_constants(self, res_stream: torch.Tensor) -> None:
+        """Write compiler-owned pinned normalization constants in place."""
+        if self.rms_norm_spec is None:
+            return
+        for column, value in zip(
+            self.rms_norm_spec.reserved_cols,
+            self.rms_norm_spec.const_values,
+            strict=False,
+        ):
+            res_stream[:, column] = value
+
     def get_input_res_stream(
         self,
         n_pos: int,
@@ -150,6 +162,13 @@ class HeadlessTransformer:
         assert self.residual_assignment
         in_state = self.layers[0].attn.in_state
         res_stream = torch.zeros((n_pos, self.d))
+
+        # Pinned RMSNorm columns are compiler-owned constants rather than graph
+        # nodes, so residual assignment does not enumerate them below. Seed
+        # them here to keep every headless consumer on the same initialization
+        # path. Token exporters fold these values into every embedding row;
+        # continuous export stores this tensor directly.
+        self._seed_rms_norm_constants(res_stream)
 
         for node in self.residual_assignment.get_nodes(in_state):
             indices = self.residual_assignment.get_node_indices(in_state, node)


### PR DESCRIPTION
This PR adds a continuous-input / continuous-output execution path to Torchwright alongside the existing token-oriented compilation workflow.

The new path allows compiled transformers to act as numerical state-transition functions of the form

$S_{k+1} = T_\theta(S_k, u_k)$

where inputs and outputs are named floating-point tensors rather than token IDs and logits.

Continuous values are written directly into the compiler-assigned residual-stream coordinates, remain in the residual stream during execution, and are extracted from the raw compiled residual after the transformer layers.

### What this adds

- `compile_continuous_hf_bundle(...)` for compiling graphs with named `InputNode` inputs and one or more named tensor outputs.
- `ContinuousRunner` for invoking compiled bundles using ordinary PyTorch tensors.
- Continuous `inputs_embeds` support in the custom Hugging Face model.
- `forward_residual()` for retrieving the raw compiled residual before final token-oriented RMSNorm and LM-head processing.
- A versioned `continuous_io.json` interface describing input/output shapes and residual-column assignments.
- A stored compiler-generated base residual containing literals and other static residual values.
- Unbatched and batched continuous execution.
- Input-name, shape, width, and batching validation.
- `run_until(...)` for generic recurrent state transitions with model-computed stopping conditions.
- Documentation and tests covering continuous input/output execution and recurrence.

### Example

```python
state = InputNode("state", 4, value_range=(-100.0, 100.0))
update = InputNode("update", 4, value_range=(-10.0, 10.0))

next_state = Add(state, update)

compile_continuous_hf_bundle(
    outputs={
        "state": next_state,
    },
    output_dir="./transition_bundle",
    n_positions=16,
)

runner = ContinuousRunner.from_pretrained("./transition_bundle")

result = runner(
    state=state_values,
    update=update_values,
)

next_state_values = result["state"]
```

For recurrent computations:

```python
result = runner.run_until(
    initial_state,
    state_input="state",
    state_output="state",
    stop_output="converged",
    max_steps=50,
    update=static_update,
)
```

Each recurrent step is a fresh transformer invocation with `use_cache=False`. The graph itself computes the stopping condition; the runtime only decides whether another invocation is required.

### Execution model

Token execution remains:

```text
token IDs
  -> embedding lookup
  -> transformer
  -> LM head
  -> logits / token IDs
```

Continuous execution instead uses:

```text
named tensors
  -> compiler-defined residual coordinates
  -> transformer
  -> raw residual
  -> named tensors
```

The continuous source graph does not contain a token `Embedding`, does not use a tokenizer, and does not route outputs through the language-model head.

The generated Hugging Face artifact still contains the minimal structural parameters and custom model/config files required by the shared HF model implementation.

### Bundle format

Continuous bundles include:

```text
config.json
model safetensors
continuous_io.json
continuous_io.safetensors
custom Torchwright HF modeling/config files
```

`continuous_io.json` records:

- the interface format version;
- fixed sequence length;
- residual width;
- fp32 dtype;
- named input/output shapes;
- residual columns assigned to each value.

`continuous_io.safetensors` stores the compiler-generated base residual. The runtime clones this tensor and overwrites only the columns corresponding to runtime inputs, ensuring residual initialization remains consistent with headless Torchwright execution.

### Compatibility

The existing token compilation path remains available, including:

- token `Embedding` graphs;
- tokenizers;
- `input_ids`;
- logits;
- LM-head behavior;
- `generate()`.

Continuous execution is implemented as a parallel interface rather than replacing token generation.

### Current limitations

- Continuous bundles currently target Torchwright's custom biased-ReLU decoder and therefore require graphs using the ReLU op library.
- Continuous execution currently uses fp32.
- `n_positions` is fixed at bundle compilation time.
- `run_until()` feeds one named state output back into one named state input; more complex recurrent state can be managed explicitly using repeated `ContinuousRunner` calls.